### PR TITLE
Improve test isolation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
   disable:
   - bodyclose
   - contextcheck
+  - deadcode
   - durationcheck
   - dupl
   - exhaustruct
@@ -42,6 +43,7 @@ linters:
   - gosec
   - gosimple
   - govet
+  - ifshort
   - interfacer
   - ireturn
   - lll
@@ -63,7 +65,7 @@ linters:
   - tparallel
   - typecheck
   - unparam
-  - unused
+  - varcheck
   - varnamelen
   - wastedassign
   - wrapcheck

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -69,6 +69,9 @@ func TestAction(t *testing.T) {
 func TestNew(t *testing.T) {
 	t.Parallel()
 
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
 	td, err := os.MkdirTemp("", "gopass-")
 	require.NoError(t, err)
 	defer func() {

--- a/internal/action/generate.go
+++ b/internal/action/generate.go
@@ -57,7 +57,7 @@ func (s *Action) Generate(c *cli.Context) error {
 	ctx := ctxutil.WithGlobalFlags(c)
 	ctx = WithClip(ctx, c.Bool("clip"))
 	force := c.Bool("force")
-	edit := c.Bool("edit") //nolint:ifshort
+	edit := c.Bool("edit")
 
 	args, kvps := parseArgs(c)
 	name := args.Get(0)
@@ -413,7 +413,7 @@ func (s *Action) CompleteGenerate(c *cli.Context) {
 	if c.Args().Len() < 1 {
 		return
 	}
-	needle := c.Args().Get(0) //nolint:ifshort
+	needle := c.Args().Get(0)
 
 	_, err := s.Store.IsInitialized(ctx) // important to make sure the structs are not nil.
 	if err != nil {

--- a/internal/action/rcs_test.go
+++ b/internal/action/rcs_test.go
@@ -34,7 +34,7 @@ func TestGit(t *testing.T) { //nolint:paralleltest
 	}()
 
 	// git init
-	c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"username": "foobar", "useremail": "foo.bar@example.org"})
+	c := gptest.CliCtxWithFlags(ctx, t, map[string]string{"name": "foobar", "email": "foo.bar@example.org"})
 	assert.NoError(t, act.RCSInit(c))
 	buf.Reset()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,13 +1,12 @@
 package config_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	_ "github.com/kpitt/gopass/internal/backend/crypto"
 	_ "github.com/kpitt/gopass/internal/backend/storage"
 	"github.com/kpitt/gopass/internal/config"
+	"github.com/kpitt/gopass/tests/gptest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +15,8 @@ func TestHomedir(t *testing.T) { //nolint:paralleltest
 }
 
 func TestNewConfig(t *testing.T) { //nolint:paralleltest
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
 
 	cfg := config.New()
 	cs := cfg.String()
@@ -35,7 +35,8 @@ func TestNewConfig(t *testing.T) { //nolint:paralleltest
 }
 
 func TestSetConfigValue(t *testing.T) { //nolint:paralleltest
-	assert.NoError(t, os.Setenv("GOPASS_CONFIG", filepath.Join(os.TempDir(), ".gopass.yml")))
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
 
 	cfg := config.New()
 	assert.NoError(t, cfg.SetConfigValue("autoclip", "true"))

--- a/internal/store/leaf/reencrypt.go
+++ b/internal/store/leaf/reencrypt.go
@@ -16,8 +16,6 @@ import (
 )
 
 // reencrypt will re-encrypt all entries for the current recipients.
-//
-//nolint:ifshort
 func (s *Store) reencrypt(ctx context.Context) error {
 	entries, err := s.List(ctx, "")
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -33,6 +33,9 @@ func TestVersionPrinter(t *testing.T) {
 func TestSetupApp(t *testing.T) {
 	t.Parallel()
 
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
 	ctx := context.Background()
 	_, app := setupApp(ctx, "1.9.0", "2022-08-17")
 	assert.NotNil(t, app)
@@ -158,6 +161,9 @@ func testCommands(t *testing.T, c *cli.Context, commands []*cli.Command, prefix 
 
 func TestInitContext(t *testing.T) {
 	t.Parallel()
+
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
 
 	ctx := context.Background()
 	cfg := config.New()

--- a/tests/gptest/utils.go
+++ b/tests/gptest/utils.go
@@ -25,6 +25,11 @@ func AllPathsToSlash(paths []string) []string {
 }
 
 func setupEnv(em map[string]string) error {
+	// Make sure there are no left-over Git environment variables that could
+	// interfere with the expected test results.
+	_ = os.Unsetenv("GIT_AUTHOR_NAME")
+	_ = os.Unsetenv("GIT_AUTHOR_EMAIL")
+
 	for k, v := range em {
 		if err := os.Setenv(k, v); err != nil {
 			return fmt.Errorf("failed to set env %s to %s: %w", k, v, err)


### PR DESCRIPTION
Some tests are picking up too much real user data from the current environment. There are also some test conditions that aren't always cleared properly between test cases, which can affect the results of later tests.