### PR TITLE
Improve auto-sync handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20220730123233-d6ffb7692adf
 	github.com/atotto/clipboard v0.1.4
 	github.com/blang/semver/v4 v4.0.0
+	github.com/briandowns/spinner v1.19.0
 	github.com/caspr-io/yamlpath v0.0.0-20200722075116-502e8d113a9b
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fatih/color v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/briandowns/spinner v1.19.0 h1:s8aq38H+Qju89yhp89b4iIiMzMm8YN3p6vGpwyh/a8E=
+github.com/briandowns/spinner v1.19.0/go.mod h1:mQak9GHqbspjC/5iUx3qMlIho8xBS/ppAL/hX5SmPJU=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/bwesterb/go-ristretto v1.2.1/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/caspr-io/yamlpath v0.0.0-20200722075116-502e8d113a9b h1:2K3B6Xm7/lnhOugeGB3nIk50bZ9zhuJvXCEfUuL68ik=
@@ -29,6 +31,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/godbus/dbus v0.0.0-20190623212516-8a1682060722 h1:NNKZiuNXd6lpZRyoFM/uhssj5W9Ps1DbhGHxT49Pm9I=
@@ -75,6 +78,7 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/martinhoefling/goxkcdpwgen v0.1.1 h1:cUPlcs35f0O863EHUnk2k9Rrj2gY1Jk6LzmUtxWlyUU=
 github.com/martinhoefling/goxkcdpwgen v0.1.1/go.mod h1:ZksVqSs26I/A6zASske3+yoieIc2J9Xr/Va4Ce0+3RA=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=

--- a/internal/action/init.go
+++ b/internal/action/init.go
@@ -28,7 +28,9 @@ func (s *Action) IsInitialized(c *cli.Context) error {
 	if inited {
 		debug.Log("Store is fully initialized and ready to go.\n")
 		s.printReminder(ctx)
-		_ = s.autoSync(ctx)
+		if c.Command.Name != "sync" {
+			_ = s.autoSync(ctx)
+		}
 
 		return nil
 	}

--- a/internal/action/sync.go
+++ b/internal/action/sync.go
@@ -56,8 +56,6 @@ func (s *Action) autoSync(ctx context.Context) error {
 	ls := s.rem.LastSeen("autosync")
 	debug.Log("autosync - last seen: %s", ls)
 	if time.Since(ls) > time.Duration(autosyncIntervalDays)*24*time.Hour {
-		_ = s.rem.Reset("autosync")
-
 		return s.sync(ctx, "")
 	}
 
@@ -84,6 +82,11 @@ func (s *Action) sync(ctx context.Context, store string) error {
 		_ = s.syncMount(ctx, mp)
 	}
 	out.OKf(ctx, "All done")
+
+	// If we are sync'ing all stores, and sync succeeds, then reset the auto-sync interval.
+	if store == "" {
+		_ = s.rem.Reset("autosync")
+	}
 
 	return nil
 }

--- a/internal/out/print.go
+++ b/internal/out/print.go
@@ -40,6 +40,7 @@ func Print(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "%s", arg)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"%s"+newline(ctx), arg)
 }
@@ -49,6 +50,7 @@ func Printf(ctx context.Context, format string, args ...any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+format+newline(ctx), args...)
 }
@@ -58,6 +60,7 @@ func Notice(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "NOTICE: %s", arg)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"! %s"+newline(ctx), arg)
 }
@@ -67,6 +70,7 @@ func Noticef(ctx context.Context, format string, args ...any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "NOTICE: "+format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"! "+format+newline(ctx), args...)
 }
@@ -76,6 +80,7 @@ func Error(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "ERROR: %s", arg)
 	fmt.Fprint(Stderr, color.RedString(Prefix(ctx)+"✗ %s"+newline(ctx), arg))
 }
@@ -85,6 +90,7 @@ func Errorf(ctx context.Context, format string, args ...any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "ERROR: "+format, args...)
 	fmt.Fprint(Stderr, color.RedString(Prefix(ctx)+"✗ "+format+newline(ctx), args...))
 }
@@ -94,6 +100,7 @@ func OK(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "OK: %s", arg)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"✓ %s"+newline(ctx), arg)
 }
@@ -103,6 +110,7 @@ func OKf(ctx context.Context, format string, args ...any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "OK: "+format, args...)
 	fmt.Fprintf(Stdout, Prefix(ctx)+"✓ "+format+newline(ctx), args...)
 }
@@ -112,6 +120,7 @@ func Warning(ctx context.Context, arg any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "WARNING: %s", arg)
 	fmt.Fprint(Stderr, color.YellowString(Prefix(ctx)+"! %s"+newline(ctx), arg))
 }
@@ -121,6 +130,12 @@ func Warningf(ctx context.Context, format string, args ...any) {
 	if ctxutil.IsHidden(ctx) {
 		return
 	}
+	stopSpinner(ctx)
 	debug.LogN(1, "WARNING: "+format, args...)
 	fmt.Fprint(Stderr, color.YellowString(Prefix(ctx)+"! "+format+newline(ctx), args...))
+}
+
+// stopSpinner stops the progress spinner if one is set.
+func stopSpinner(ctx context.Context) {
+	ctxutil.StopSpinner(ctx)
 }

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -3,7 +3,9 @@ package ctxutil
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/kpitt/gopass/internal/store"
 	"github.com/urfave/cli/v2"
 )
@@ -29,6 +31,7 @@ const (
 	ctxKeyPasswordCallback
 	ctxKeyShowParsing
 	ctxKeyHidden
+	ctxKeySpinner
 )
 
 // ErrNoCallback is returned when no callback is set in the context.
@@ -402,4 +405,38 @@ func IsHidden(ctx context.Context) bool {
 	}
 
 	return bv
+}
+
+// WithSpinner returns a context with a progress spinner showing the specified `msg`.
+func WithSpinner(ctx context.Context, msg string) context.Context {
+	sp := spinner.New(spinner.CharSets[14], 40*time.Millisecond)
+	_ = sp.Color("cyan")
+	sp.Suffix = " " + msg
+	sp.Start()
+
+	return context.WithValue(ctx, ctxKeySpinner, sp)
+}
+
+// HasSpinner returns true if a progress spinner has been set.
+func HasSpinner(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeySpinner).(*spinner.Spinner)
+
+	return ok
+}
+
+// GetSpinner returns the set progress spinner, or nil if not set.
+func GetSpinner(ctx context.Context) *spinner.Spinner {
+	sp, ok := ctx.Value(ctxKeySpinner).(*spinner.Spinner)
+	if !ok || sp == nil {
+		return nil
+	}
+
+	return sp
+}
+
+// StopSpinner stops the current progress spinner if one is set.
+func StopSpinner(ctx context.Context) {
+	if sp := GetSpinner(ctx); sp != nil {
+		sp.Stop()
+	}
 }


### PR DESCRIPTION
Handling of auto-sync is improved so that it is less likely to kick off at times that don't make sense:
- Auto-sync won't run before a manual `sync` command.
- A complete manual `sync` resets the auto-sync interval so that auto-sync won't run again too soon.

This also simplifies the progress indication for a sync operation so that the extra output is less obtrusive when auto-sync runs.